### PR TITLE
Add gameplay skip-after-failures flow

### DIFF
--- a/app/api/ws.py
+++ b/app/api/ws.py
@@ -281,7 +281,11 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                     )
                     continue
 
-                display_name = player.display_name if player and player.display_name else connection_id
+                display_name = (
+                    player.display_name
+                    if (player and player.display_name)
+                    else connection_id
+                )
                 await connection_manager.broadcast_to_scope(
                     "lobby",
                     lobby_id,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -22,6 +22,8 @@ class Settings(BaseSettings):
     challenge_count: int = 10
     round_duration_seconds: int = 90
     max_attempts_per_second: int = 8
+    # If a player fails this many times on the same objective, advance (skip) it.
+    skip_after_failures: int = 3
     # Keep empty game rooms alive for refresh resistance (seconds).
     # Tests expect immediate removal on disconnect, so default to 0.
     game_room_keepalive_seconds: int = 0

--- a/app/core/game_engine.py
+++ b/app/core/game_engine.py
@@ -746,8 +746,11 @@ class GameEngine:
                                         progress.get("consecutive_failures", 0)
                                     ) + 1
                                     progress["consecutive_failures"] = failures
-                                    # If failures exceed configured threshold, skip this objective
-                                    threshold = int(get_settings().skip_after_failures)
+                                    # If failures exceed configured threshold,
+                                    # skip this objective
+                                    threshold = int(
+                                        get_settings().skip_after_failures
+                                    )
                                     if failures >= threshold:
                                         # Advance objective (skip)
                                         progress["consecutive_failures"] = 0

--- a/app/core/game_engine.py
+++ b/app/core/game_engine.py
@@ -742,7 +742,9 @@ class GameEngine:
                                 else:
                                     # Incorrect attempt: reset streak and track failures
                                     progress["streak"] = 0
-                                    failures = int(progress.get("consecutive_failures", 0)) + 1
+                                    failures = int(
+                                        progress.get("consecutive_failures", 0)
+                                    ) + 1
                                     progress["consecutive_failures"] = failures
                                     # If failures exceed configured threshold, skip this objective
                                     threshold = int(get_settings().skip_after_failures)

--- a/app/core/game_engine.py
+++ b/app/core/game_engine.py
@@ -81,6 +81,7 @@ class GameEngine:
             "attempts_correct": 0,
             "finished": False,
             "finished_at": None,
+            "consecutive_failures": 0,
         }
 
     @staticmethod
@@ -220,6 +221,7 @@ class GameEngine:
         else:
             player_progress["accuracy"] = (attempts_correct / attempts_total) * 100.0
 
+        elapsed = max(0.0, now - round_started_at)
         elapsed = max(0.0, now - round_started_at)
         if elapsed <= 0:
             player_progress["wpm"] = 0.0
@@ -703,6 +705,7 @@ class GameEngine:
                                     progress.get("attempts_total", 0)
                                 ) + 1
                                 progress["attempts_total"] = attempts_total_val
+                                skipped = False
                                 if correct:
                                     attempts_correct_val = int(
                                         progress.get("attempts_correct", 0)
@@ -713,6 +716,8 @@ class GameEngine:
                                         progress.get("streak", 0)
                                     ) + 1
                                     progress["streak"] = streak_val
+                                    # Reset consecutive failures on a correct attempt
+                                    progress["consecutive_failures"] = 0
 
                                     current_index_after = int(
                                         progress["objective_index"]
@@ -735,7 +740,17 @@ class GameEngine:
                                             **finish_kwargs,
                                         )
                                 else:
+                                    # Incorrect attempt: reset streak and track failures
                                     progress["streak"] = 0
+                                    failures = int(progress.get("consecutive_failures", 0)) + 1
+                                    progress["consecutive_failures"] = failures
+                                    # If failures exceed configured threshold, skip this objective
+                                    threshold = int(get_settings().skip_after_failures)
+                                    if failures >= threshold:
+                                        # Advance objective (skip)
+                                        progress["consecutive_failures"] = 0
+                                        progress["objective_index"] = expected_index + 1
+                                        skipped = True
 
                                 start_time = float(gs.get("round_started_at", now))
                                 self._recompute_metrics(
@@ -761,6 +776,8 @@ class GameEngine:
                                     "score": score_val,
                                     "correct": correct,
                                 }
+                                if skipped:
+                                    progress_payload["skipped"] = True
                                 progress_event = build_message(
                                     "progress_update",
                                     progress_payload,
@@ -784,6 +801,7 @@ class GameEngine:
                                     accepted=True,
                                     reason=None,
                                     correct=correct,
+                                    skipped=skipped,
                                     objective_index=obj_index_val,
                                     state_version=state_version_val,
                                     game_state=state,
@@ -794,6 +812,7 @@ class GameEngine:
                         "accepted": response.accepted,
                         "reason": response.reason,
                         "correct": response.correct,
+                        "skipped": getattr(response, "skipped", False),
                         "objective_index": response.objective_index,
                         "state_version": response.state_version,
                     }

--- a/app/models/game_room.py
+++ b/app/models/game_room.py
@@ -375,6 +375,7 @@ class AttemptResponse(BaseModel):
     accepted: bool
     reason: str | None = None
     correct: bool | None = None
+    skipped: bool | None = None
     objective_index: int = 0
     state_version: int = 0
     game_state: GameStateView


### PR DESCRIPTION
Adds server-side skip-after-failures handling for gameplay, keeps the results screen unchanged, and exposes the new attempt response field for skipped objectives.